### PR TITLE
Add default value for useContractValue({sorobanContext}) param

### DIFF
--- a/packages/contracts/src/useContractValue.tsx
+++ b/packages/contracts/src/useContractValue.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as SorobanClient from "soroban-client";
-import { SorobanContextType } from "@soroban-react/core";
+import { SorobanContextType, useSorobanReact } from "@soroban-react/core";
 
 let xdr = SorobanClient.xdr; 
  
@@ -26,8 +26,12 @@ export interface useContractValueProps {
 // might be better named `useSimulateTransaction`, but not sure which is more clear...
 // TODO: Allow user to specify the wallet of the submitter, fees, etc... Maybe
 // a separate (lower-level) hook for `useSimulateTransaction` would be cleaner?
-export function useContractValue(
-  {contractId, method, params, sorobanContext}: useContractValueProps): ContractValueType {
+export function useContractValue({
+  contractId,
+  method,
+  params,
+  sorobanContext=useSorobanReact()
+}: useContractValueProps): ContractValueType {
 
   const { activeChain, server } = sorobanContext
 


### PR DESCRIPTION
This should make `useContractValue` easier to use. For example, in https://github.com/stellar/soroban-example-dapp/pull/79, we can remove all the `sorobanContext` params when calling it.