### PR TITLE
Rename standalone mode to localnet mode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,9 +37,9 @@ export const allowedChains: Record<ChainName, ChainMetadata> = {
     name: "Sandbox",
     networkPassphrase: SorobanClient.Networks.SANDBOX,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "Localnet",
     networkPassphrase: "Standalone Network ; February 2017",
   },
 };

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ yarn add soroban-client
 ### 2. Set your allowed chains for your Dapp
 ```
 import * as SorobanClient from "soroban-client";
-import type {ChainMetadata, ChainName} from '@soroban-react/types';
+import type {ChainMetadata} from '@soroban-react/types';
+import type {ChainName} from '@soroban-react/chains';
 
 export const allowedChains: Record<ChainName, ChainMetadata> = {
   public: {

--- a/packages/chains/README.md
+++ b/packages/chains/README.md
@@ -7,7 +7,8 @@ This package will charge the follwing chains:
 
 ```
 import * as SorobanClient from "soroban-client";
-import type {ChainMetadata, ChainName} from '@soroban-react/types';
+import type {ChainMetadata} from '@soroban-react/types';
+import type {ChainName} from '@soroban-react/chains';
 
 export const allowedChains: Record<ChainName, ChainMetadata> = {
   public: {

--- a/packages/chains/README.md
+++ b/packages/chains/README.md
@@ -30,9 +30,9 @@ export const allowedChains: Record<ChainName, ChainMetadata> = {
     name: "Sandbox",
     networkPassphrase: SorobanClient.Networks.SANDBOX,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "Localnet",
     networkPassphrase: "Standalone Network ; February 2017",
   },
 };

--- a/packages/chains/src/index.tsx
+++ b/packages/chains/src/index.tsx
@@ -22,9 +22,9 @@ export const chains: Record<ChainName, ChainMetadata> = {
     name: "Sandbox",
     networkPassphrase: SorobanClient.Networks.SANDBOX,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "Localnet",
     networkPassphrase: "Standalone Network ; February 2017",
   },
 };

--- a/packages/chains/src/index.tsx
+++ b/packages/chains/src/index.tsx
@@ -1,5 +1,14 @@
 import * as SorobanClient from "soroban-client";
-import type {ChainMetadata, ChainName} from '@soroban-react/types';
+import type {ChainMetadata} from '@soroban-react/types';
+
+// Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
+// This is just so we can clearly see which of wagmi's first-class chains we provide metadata for
+export type ChainName =
+  | 'futurenet'
+  | 'public'
+  | 'testnet'
+  | 'sandbox'
+  | 'localnet';
 
 export const chains: Record<ChainName, ChainMetadata> = {
   public: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "/dist"
   ],
   "dependencies": {
+    "@soroban-react/chains": "^3.2.1",
     "@soroban-react/freighter": "^3.2.1",
     "@soroban-react/types": "^3.2.1",
     "soroban-client": "^0.3.0"

--- a/packages/core/src/utils/provideWalletChains.tsx
+++ b/packages/core/src/utils/provideWalletChains.tsx
@@ -34,9 +34,9 @@ const chainMetadataByName: Record<ChainName, ChainMetadata> = {
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "Localnet",
     networkPassphrase: "Standalone Network ; February 2017",
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,

--- a/packages/core/src/utils/provideWalletChains.tsx
+++ b/packages/core/src/utils/provideWalletChains.tsx
@@ -1,6 +1,7 @@
 import * as SorobanClient from "soroban-client";
 import { isNotNullish } from './isNotNullish';
-import type { WalletChain, ChainMetadata, ChainName} from '@soroban-react/types';
+import type { WalletChain, ChainMetadata} from '@soroban-react/types';
+import type {ChainName} from '@soroban-react/chains';
 
 // Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
 // This is just so we can clearly see which of wagmi's first-class chains we provide metadata for

--- a/packages/types/src/index.tsx
+++ b/packages/types/src/index.tsx
@@ -41,13 +41,4 @@ export interface WalletChain {
   unsupported?: boolean;
 };
 
-// Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
-// This is just so we can clearly see which of wagmi's first-class chains we provide metadata for
-export type ChainName =
-  | 'futurenet'
-  | 'public'
-  | 'testnet'
-  | 'sandbox'
-  | 'localnet';
-
 export type ChainMetadata = WalletChain;

--- a/packages/types/src/index.tsx
+++ b/packages/types/src/index.tsx
@@ -48,6 +48,6 @@ export type ChainName =
   | 'public'
   | 'testnet'
   | 'sandbox'
-  | 'standalone';
+  | 'localnet';
 
 export type ChainMetadata = WalletChain;

--- a/packages/wallet-data/src/provideWalletChains.tsx
+++ b/packages/wallet-data/src/provideWalletChains.tsx
@@ -31,9 +31,9 @@ export const chainMetadataByName: Record<ChainName, ChainMetadata> = {
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,
   },
-  standalone: {
-    id: "standalone",
-    name: "Standalone",
+  localnet: {
+    id: "localnet",
+    name: "Localnet",
     networkPassphrase: "Standalone Network ; February 2017",
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,

--- a/packages/wallet-data/src/provideWalletChains.tsx
+++ b/packages/wallet-data/src/provideWalletChains.tsx
@@ -1,33 +1,36 @@
-import type {ChainMetadata, ChainName} from '@soroban-react/types';
+import * as SorobanClient from "soroban-client";
+import type {ChainMetadata} from '@soroban-react/types';
+import type {ChainName} from '@soroban-react/chains';
 
 // Sourced from https://github.com/tmm/wagmi/blob/main/packages/core/src/constants/chains.ts
 // This is just so we can clearly see which of wagmi's first-class chains we provide metadata for
+
 export const chainMetadataByName: Record<ChainName, ChainMetadata> = {
   public: {
     id: "public",
     name: "Public",
-    networkPassphrase: "Public Global Stellar Network ; September 2015",
+    networkPassphrase: SorobanClient.Networks.PUBLIC,
     iconBackground: '#e84141',
     // iconUrl: async () => (await import('./chainIcons/public.svg')).default,
   },
   testnet: {
     id: "testnet",
     name: "Testnet",
-    networkPassphrase: "Test SDF Network ; September 2015",
+    networkPassphrase: SorobanClient.Networks.TESTNET,
     iconBackground: '#484c50',
     // iconUrl: async () => (await import('./chainIcons/testnet.svg')).default,
   },
   futurenet: {
     id: "futurenet",
     name: "Futurenet",
-    networkPassphrase: "Test SDF Future Network ; October 2022",
+    networkPassphrase: SorobanClient.Networks.FUTURENET,
     iconBackground: '#96bedc',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,
   },
   sandbox: {
     id: "sandbox",
     name: "Sandbox",
-    networkPassphrase: "Local Sandbox Stellar Network ; September 2022",
+    networkPassphrase: SorobanClient.Networks.SANDBOX,
     iconBackground: '#dac695',
     // iconUrl: async () => (await import('./chainIcons/futurenet.svg')).default,
   },


### PR DESCRIPTION
I was working on updating https://github.com/stellar/soroban-example-dapp/pull/62 to get it merged, but some of the chain definitions from https://github.com/stellar/soroban-example-dapp/pull/62 have moved here.

We'd like to go with `localnet` as the terminology everywhere, as it seems more meaningful than `standalone`.