### PR TITLE
use non buffer format of fromXDR

### DIFF
--- a/packages/contracts/src/useContractValue.tsx
+++ b/packages/contracts/src/useContractValue.tsx
@@ -118,5 +118,5 @@ async function fetchContractValue({
     throw new Error("Invalid response from simulateTransaction");
   }
   const result = results[0];
-  return xdr.ScVal.fromXDR(Buffer.from(result.xdr, 'base64'));
+  return xdr.ScVal.fromXDR(result.xdr, "base64");
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,10 +19,10 @@
   "version": "4.5.2",
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "tsc",
+    "build": "yarn prebuild && tsc",
     "start": "tsc --watch",
     "prepare": "install-peers",
-    "test": "yarn build && yarn jest"
+    "test": "yarn prepare && yarn build && yarn jest"
   },
   "main": "./dist/index.js",
   "exports": "./dist/index.js",

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -10,7 +10,7 @@ const crowdfundPledgedEventSubscription: EventSubscription = {
       contractId: Constants.CrowdfundId, 
       topics: ['pledged_amount_changed'], 
       cb: (event: SorobanClient.SorobanRpc.EventResponse): void => {
-        let eventTokenBalance = xdr.ScVal.fromXDR(event.value.xdr, "base64")
+        let eventTokenBalance = xdr.ScVal.fromXDR(event.value.xdr, 'base64')
         setTokenBalance(convert.scvalToBigNumber(eventTokenBalance))
       }, 
       id: Math.random()}

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -10,7 +10,7 @@ const crowdfundPledgedEventSubscription: EventSubscription = {
       contractId: Constants.CrowdfundId, 
       topics: ['pledged_amount_changed'], 
       cb: (event: SorobanClient.SorobanRpc.EventResponse): void => {
-        let eventTokenBalance = xdr.ScVal.fromXDR(Buffer.from(event.value.xdr, 'base64'))
+        let eventTokenBalance = xdr.ScVal.fromXDR(event.value.xdr, "base64")
         setTokenBalance(convert.scvalToBigNumber(eventTokenBalance))
       }, 
       id: Math.random()}


### PR DESCRIPTION
fixing an issue seen in downstream client usage in browser deployments with error on `Buffer.from()` of `TypeError: this._buffer.readBigInt64BE is not a function` when passing it to soroban client `fromXDR()` methods, if the downstream client app hasn't poly-filled 'Buffer' to a version that has readBigInt64BE() included, then seeing this error raised, it can be avoided by not using Buffer.from() and instead passing xdr encoded string directly to soroban client using `fromXDR(xdr, 'base64')`