### PR TITLE
Fix/preview11

### DIFF
--- a/packages/contracts/src/contractInvoke.tsx
+++ b/packages/contracts/src/contractInvoke.tsx
@@ -1,9 +1,8 @@
-import * as SorobanClient from 'soroban-client'
+import { SorobanContextType } from '@soroban-react/core';
+import * as SorobanClient from 'soroban-client';
 import { SorobanRpc } from "soroban-client";
-import { SorobanContextType } from '@soroban-react/core'
-import type {Transaction, Tx} from './types'
-import { signAndSendTransaction } from './transaction'
-import { contractTransaction } from './contractTransaction'
+import { contractTransaction } from './contractTransaction';
+import { signAndSendTransaction } from './transaction';
 let xdr = SorobanClient.xdr 
 
 
@@ -68,7 +67,7 @@ export async function contractInvoke({
 
     if (!signAndSend && simulated) {
 
-      return simulated.result;
+      return simulated.result.retval;
     }
     else {
       // If signAndSend

--- a/packages/core/src/SorobanReactProvider.tsx
+++ b/packages/core/src/SorobanReactProvider.tsx
@@ -1,5 +1,5 @@
 import { Connector, WalletChain } from '@soroban-react/types'
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 
 import * as SorobanClient from 'soroban-client'
 
@@ -72,9 +72,10 @@ export function SorobanReactProvider({
         let activeChain = networkToActiveChain(networkDetails, chains)
 
         let address = await mySorobanContext.activeConnector?.getPublicKey()
+        //TODO: Fix how futurenet soroban rpc is handled, it should get it right from the freighter api, but for now this is the workaround
         let server =
           networkDetails &&
-          new SorobanClient.Server(networkDetails.networkUrl, {
+          new SorobanClient.Server(networkDetails.networkUrl == "https://horizon-futurenet.stellar.org" ? "https://rpc-futurenet.stellar.org" : networkDetails.networkUrl, {
             allowHttp: networkDetails.networkUrl.startsWith('http://'),
           })
 


### PR DESCRIPTION
- futurenet horizon rpc gets replaced for the soroban rpc
- contractInvoke now returns result.retval